### PR TITLE
feat: add self-closing components eslint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,8 @@ export default [
 		rules: {
 			// suppress errors for missing 'import React' in files
 			"react/react-in-jsx-scope": "off",
+			// self close react components when possible
+			"react/self-closing-comp": "error",
 		},
 	},
 ];


### PR DESCRIPTION
This new eslint rule will replace components like `<Component></Component>` with self-closing ones `<Component />` when possible. See https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md